### PR TITLE
chore: Migrate containeranalysis synth.py to bazel

### DIFF
--- a/grpc-google-cloud-containeranalysis-v1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-containeranalysis-v1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 0.119.3-beta released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/containeranalysis/v1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-containeranalysis-v1/src/main/java/com/google/containeranalysis/v1/ContainerAnalysisGrpc.java
+++ b/grpc-google-cloud-containeranalysis-v1/src/main/java/com/google/containeranalysis/v1/ContainerAnalysisGrpc.java
@@ -40,7 +40,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/devtools/containeranalysis/v1/containeranalysis.proto")
 public final class ContainerAnalysisGrpc {
 
@@ -50,26 +50,18 @@ public final class ContainerAnalysisGrpc {
       "google.devtools.containeranalysis.v1.ContainerAnalysis";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSetIamPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
-      METHOD_SET_IAM_POLICY = getSetIamPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       getSetIamPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SetIamPolicy",
+      requestType = com.google.iam.v1.SetIamPolicyRequest.class,
+      responseType = com.google.iam.v1.Policy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       getSetIamPolicyMethod() {
-    return getSetIamPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
-      getSetIamPolicyMethodHelper() {
     io.grpc.MethodDescriptor<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
         getSetIamPolicyMethod;
     if ((getSetIamPolicyMethod = ContainerAnalysisGrpc.getSetIamPolicyMethod) == null) {
@@ -80,10 +72,7 @@ public final class ContainerAnalysisGrpc {
                   io.grpc.MethodDescriptor
                       .<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.devtools.containeranalysis.v1.ContainerAnalysis",
-                              "SetIamPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SetIamPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -100,26 +89,18 @@ public final class ContainerAnalysisGrpc {
     return getSetIamPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetIamPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
-      METHOD_GET_IAM_POLICY = getGetIamPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       getGetIamPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetIamPolicy",
+      requestType = com.google.iam.v1.GetIamPolicyRequest.class,
+      responseType = com.google.iam.v1.Policy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       getGetIamPolicyMethod() {
-    return getGetIamPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
-      getGetIamPolicyMethodHelper() {
     io.grpc.MethodDescriptor<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
         getGetIamPolicyMethod;
     if ((getGetIamPolicyMethod = ContainerAnalysisGrpc.getGetIamPolicyMethod) == null) {
@@ -130,10 +111,7 @@ public final class ContainerAnalysisGrpc {
                   io.grpc.MethodDescriptor
                       .<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.devtools.containeranalysis.v1.ContainerAnalysis",
-                              "GetIamPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetIamPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -150,26 +128,18 @@ public final class ContainerAnalysisGrpc {
     return getGetIamPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getTestIamPermissionsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
-      METHOD_TEST_IAM_PERMISSIONS = getTestIamPermissionsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       getTestIamPermissionsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "TestIamPermissions",
+      requestType = com.google.iam.v1.TestIamPermissionsRequest.class,
+      responseType = com.google.iam.v1.TestIamPermissionsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       getTestIamPermissionsMethod() {
-    return getTestIamPermissionsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
-      getTestIamPermissionsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.iam.v1.TestIamPermissionsRequest,
             com.google.iam.v1.TestIamPermissionsResponse>
@@ -185,10 +155,7 @@ public final class ContainerAnalysisGrpc {
                           com.google.iam.v1.TestIamPermissionsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.devtools.containeranalysis.v1.ContainerAnalysis",
-                              "TestIamPermissions"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "TestIamPermissions"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -207,19 +174,43 @@ public final class ContainerAnalysisGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ContainerAnalysisStub newStub(io.grpc.Channel channel) {
-    return new ContainerAnalysisStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ContainerAnalysisStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ContainerAnalysisStub>() {
+          @java.lang.Override
+          public ContainerAnalysisStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ContainerAnalysisStub(channel, callOptions);
+          }
+        };
+    return ContainerAnalysisStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ContainerAnalysisBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ContainerAnalysisBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ContainerAnalysisBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ContainerAnalysisBlockingStub>() {
+          @java.lang.Override
+          public ContainerAnalysisBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ContainerAnalysisBlockingStub(channel, callOptions);
+          }
+        };
+    return ContainerAnalysisBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ContainerAnalysisFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ContainerAnalysisFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ContainerAnalysisFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ContainerAnalysisFutureStub>() {
+          @java.lang.Override
+          public ContainerAnalysisFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ContainerAnalysisFutureStub(channel, callOptions);
+          }
+        };
+    return ContainerAnalysisFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -257,7 +248,7 @@ public final class ContainerAnalysisGrpc {
     public void setIamPolicy(
         com.google.iam.v1.SetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
-      asyncUnimplementedUnaryCall(getSetIamPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSetIamPolicyMethod(), responseObserver);
     }
 
     /**
@@ -276,7 +267,7 @@ public final class ContainerAnalysisGrpc {
     public void getIamPolicy(
         com.google.iam.v1.GetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetIamPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetIamPolicyMethod(), responseObserver);
     }
 
     /**
@@ -295,26 +286,26 @@ public final class ContainerAnalysisGrpc {
         com.google.iam.v1.TestIamPermissionsRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.TestIamPermissionsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getTestIamPermissionsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getTestIamPermissionsMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getSetIamPolicyMethodHelper(),
+              getSetIamPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>(
                       this, METHODID_SET_IAM_POLICY)))
           .addMethod(
-              getGetIamPolicyMethodHelper(),
+              getGetIamPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>(
                       this, METHODID_GET_IAM_POLICY)))
           .addMethod(
-              getTestIamPermissionsMethodHelper(),
+              getTestIamPermissionsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.TestIamPermissionsRequest,
@@ -342,11 +333,7 @@ public final class ContainerAnalysisGrpc {
    * </pre>
    */
   public static final class ContainerAnalysisStub
-      extends io.grpc.stub.AbstractStub<ContainerAnalysisStub> {
-    private ContainerAnalysisStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<ContainerAnalysisStub> {
     private ContainerAnalysisStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -374,7 +361,7 @@ public final class ContainerAnalysisGrpc {
         com.google.iam.v1.SetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSetIamPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getSetIamPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -396,7 +383,7 @@ public final class ContainerAnalysisGrpc {
         com.google.iam.v1.GetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetIamPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetIamPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -418,7 +405,7 @@ public final class ContainerAnalysisGrpc {
         io.grpc.stub.StreamObserver<com.google.iam.v1.TestIamPermissionsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getTestIamPermissionsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getTestIamPermissionsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -442,11 +429,7 @@ public final class ContainerAnalysisGrpc {
    * </pre>
    */
   public static final class ContainerAnalysisBlockingStub
-      extends io.grpc.stub.AbstractStub<ContainerAnalysisBlockingStub> {
-    private ContainerAnalysisBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ContainerAnalysisBlockingStub> {
     private ContainerAnalysisBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -472,8 +455,7 @@ public final class ContainerAnalysisGrpc {
      * </pre>
      */
     public com.google.iam.v1.Policy setIamPolicy(com.google.iam.v1.SetIamPolicyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getSetIamPolicyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSetIamPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -490,8 +472,7 @@ public final class ContainerAnalysisGrpc {
      * </pre>
      */
     public com.google.iam.v1.Policy getIamPolicy(com.google.iam.v1.GetIamPolicyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetIamPolicyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetIamPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -509,7 +490,7 @@ public final class ContainerAnalysisGrpc {
     public com.google.iam.v1.TestIamPermissionsResponse testIamPermissions(
         com.google.iam.v1.TestIamPermissionsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getTestIamPermissionsMethodHelper(), getCallOptions(), request);
+          getChannel(), getTestIamPermissionsMethod(), getCallOptions(), request);
     }
   }
 
@@ -531,11 +512,7 @@ public final class ContainerAnalysisGrpc {
    * </pre>
    */
   public static final class ContainerAnalysisFutureStub
-      extends io.grpc.stub.AbstractStub<ContainerAnalysisFutureStub> {
-    private ContainerAnalysisFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ContainerAnalysisFutureStub> {
     private ContainerAnalysisFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -562,7 +539,7 @@ public final class ContainerAnalysisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.iam.v1.Policy>
         setIamPolicy(com.google.iam.v1.SetIamPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getSetIamPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getSetIamPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -581,7 +558,7 @@ public final class ContainerAnalysisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.iam.v1.Policy>
         getIamPolicy(com.google.iam.v1.GetIamPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetIamPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetIamPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -600,7 +577,7 @@ public final class ContainerAnalysisGrpc {
             com.google.iam.v1.TestIamPermissionsResponse>
         testIamPermissions(com.google.iam.v1.TestIamPermissionsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getTestIamPermissionsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getTestIamPermissionsMethod(), getCallOptions()), request);
     }
   }
 
@@ -705,9 +682,9 @@ public final class ContainerAnalysisGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ContainerAnalysisFileDescriptorSupplier())
-                      .addMethod(getSetIamPolicyMethodHelper())
-                      .addMethod(getGetIamPolicyMethodHelper())
-                      .addMethod(getTestIamPermissionsMethodHelper())
+                      .addMethod(getSetIamPolicyMethod())
+                      .addMethod(getGetIamPolicyMethod())
+                      .addMethod(getTestIamPermissionsMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-containeranalysis-v1beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-containeranalysis-v1beta1/clirr-ignored-differences.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 0.119.3-beta released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/containeranalysis/v1beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+  <difference>
+    <!-- TODO: remove after 0.119.3-beta released -->
+    <differenceType>6001</differenceType>
+    <className>io/grafeas/v1beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-containeranalysis-v1beta1/src/main/java/com/google/containeranalysis/v1beta1/ContainerAnalysisV1Beta1Grpc.java
+++ b/grpc-google-cloud-containeranalysis-v1beta1/src/main/java/com/google/containeranalysis/v1beta1/ContainerAnalysisV1Beta1Grpc.java
@@ -40,7 +40,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/devtools/containeranalysis/v1beta1/containeranalysis.proto")
 public final class ContainerAnalysisV1Beta1Grpc {
 
@@ -50,26 +50,18 @@ public final class ContainerAnalysisV1Beta1Grpc {
       "google.devtools.containeranalysis.v1beta1.ContainerAnalysisV1Beta1";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSetIamPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
-      METHOD_SET_IAM_POLICY = getSetIamPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       getSetIamPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SetIamPolicy",
+      requestType = com.google.iam.v1.SetIamPolicyRequest.class,
+      responseType = com.google.iam.v1.Policy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       getSetIamPolicyMethod() {
-    return getSetIamPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
-      getSetIamPolicyMethodHelper() {
     io.grpc.MethodDescriptor<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
         getSetIamPolicyMethod;
     if ((getSetIamPolicyMethod = ContainerAnalysisV1Beta1Grpc.getSetIamPolicyMethod) == null) {
@@ -80,10 +72,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
                   io.grpc.MethodDescriptor
                       .<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.devtools.containeranalysis.v1beta1.ContainerAnalysisV1Beta1",
-                              "SetIamPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SetIamPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -100,26 +89,18 @@ public final class ContainerAnalysisV1Beta1Grpc {
     return getSetIamPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetIamPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
-      METHOD_GET_IAM_POLICY = getGetIamPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       getGetIamPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetIamPolicy",
+      requestType = com.google.iam.v1.GetIamPolicyRequest.class,
+      responseType = com.google.iam.v1.Policy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       getGetIamPolicyMethod() {
-    return getGetIamPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
-      getGetIamPolicyMethodHelper() {
     io.grpc.MethodDescriptor<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
         getGetIamPolicyMethod;
     if ((getGetIamPolicyMethod = ContainerAnalysisV1Beta1Grpc.getGetIamPolicyMethod) == null) {
@@ -130,10 +111,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
                   io.grpc.MethodDescriptor
                       .<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.devtools.containeranalysis.v1beta1.ContainerAnalysisV1Beta1",
-                              "GetIamPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetIamPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -150,26 +128,18 @@ public final class ContainerAnalysisV1Beta1Grpc {
     return getGetIamPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getTestIamPermissionsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
-      METHOD_TEST_IAM_PERMISSIONS = getTestIamPermissionsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       getTestIamPermissionsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "TestIamPermissions",
+      requestType = com.google.iam.v1.TestIamPermissionsRequest.class,
+      responseType = com.google.iam.v1.TestIamPermissionsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       getTestIamPermissionsMethod() {
-    return getTestIamPermissionsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
-      getTestIamPermissionsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.iam.v1.TestIamPermissionsRequest,
             com.google.iam.v1.TestIamPermissionsResponse>
@@ -186,10 +156,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
                           com.google.iam.v1.TestIamPermissionsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.devtools.containeranalysis.v1beta1.ContainerAnalysisV1Beta1",
-                              "TestIamPermissions"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "TestIamPermissions"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -207,30 +174,20 @@ public final class ContainerAnalysisV1Beta1Grpc {
     return getTestIamPermissionsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetScanConfigMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.containeranalysis.v1beta1.GetScanConfigRequest,
-          com.google.containeranalysis.v1beta1.ScanConfig>
-      METHOD_GET_SCAN_CONFIG = getGetScanConfigMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.containeranalysis.v1beta1.GetScanConfigRequest,
           com.google.containeranalysis.v1beta1.ScanConfig>
       getGetScanConfigMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetScanConfig",
+      requestType = com.google.containeranalysis.v1beta1.GetScanConfigRequest.class,
+      responseType = com.google.containeranalysis.v1beta1.ScanConfig.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.containeranalysis.v1beta1.GetScanConfigRequest,
           com.google.containeranalysis.v1beta1.ScanConfig>
       getGetScanConfigMethod() {
-    return getGetScanConfigMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.containeranalysis.v1beta1.GetScanConfigRequest,
-          com.google.containeranalysis.v1beta1.ScanConfig>
-      getGetScanConfigMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.containeranalysis.v1beta1.GetScanConfigRequest,
             com.google.containeranalysis.v1beta1.ScanConfig>
@@ -246,10 +203,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
                           com.google.containeranalysis.v1beta1.ScanConfig>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.devtools.containeranalysis.v1beta1.ContainerAnalysisV1Beta1",
-                              "GetScanConfig"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetScanConfig"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -267,30 +221,20 @@ public final class ContainerAnalysisV1Beta1Grpc {
     return getGetScanConfigMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListScanConfigsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.containeranalysis.v1beta1.ListScanConfigsRequest,
-          com.google.containeranalysis.v1beta1.ListScanConfigsResponse>
-      METHOD_LIST_SCAN_CONFIGS = getListScanConfigsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.containeranalysis.v1beta1.ListScanConfigsRequest,
           com.google.containeranalysis.v1beta1.ListScanConfigsResponse>
       getListScanConfigsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListScanConfigs",
+      requestType = com.google.containeranalysis.v1beta1.ListScanConfigsRequest.class,
+      responseType = com.google.containeranalysis.v1beta1.ListScanConfigsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.containeranalysis.v1beta1.ListScanConfigsRequest,
           com.google.containeranalysis.v1beta1.ListScanConfigsResponse>
       getListScanConfigsMethod() {
-    return getListScanConfigsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.containeranalysis.v1beta1.ListScanConfigsRequest,
-          com.google.containeranalysis.v1beta1.ListScanConfigsResponse>
-      getListScanConfigsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.containeranalysis.v1beta1.ListScanConfigsRequest,
             com.google.containeranalysis.v1beta1.ListScanConfigsResponse>
@@ -307,10 +251,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
                           com.google.containeranalysis.v1beta1.ListScanConfigsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.devtools.containeranalysis.v1beta1.ContainerAnalysisV1Beta1",
-                              "ListScanConfigs"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListScanConfigs"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -329,30 +270,20 @@ public final class ContainerAnalysisV1Beta1Grpc {
     return getListScanConfigsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateScanConfigMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.containeranalysis.v1beta1.UpdateScanConfigRequest,
-          com.google.containeranalysis.v1beta1.ScanConfig>
-      METHOD_UPDATE_SCAN_CONFIG = getUpdateScanConfigMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.containeranalysis.v1beta1.UpdateScanConfigRequest,
           com.google.containeranalysis.v1beta1.ScanConfig>
       getUpdateScanConfigMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateScanConfig",
+      requestType = com.google.containeranalysis.v1beta1.UpdateScanConfigRequest.class,
+      responseType = com.google.containeranalysis.v1beta1.ScanConfig.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.containeranalysis.v1beta1.UpdateScanConfigRequest,
           com.google.containeranalysis.v1beta1.ScanConfig>
       getUpdateScanConfigMethod() {
-    return getUpdateScanConfigMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.containeranalysis.v1beta1.UpdateScanConfigRequest,
-          com.google.containeranalysis.v1beta1.ScanConfig>
-      getUpdateScanConfigMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.containeranalysis.v1beta1.UpdateScanConfigRequest,
             com.google.containeranalysis.v1beta1.ScanConfig>
@@ -369,10 +300,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
                           com.google.containeranalysis.v1beta1.ScanConfig>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.devtools.containeranalysis.v1beta1.ContainerAnalysisV1Beta1",
-                              "UpdateScanConfig"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateScanConfig"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -392,19 +320,43 @@ public final class ContainerAnalysisV1Beta1Grpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ContainerAnalysisV1Beta1Stub newStub(io.grpc.Channel channel) {
-    return new ContainerAnalysisV1Beta1Stub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ContainerAnalysisV1Beta1Stub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ContainerAnalysisV1Beta1Stub>() {
+          @java.lang.Override
+          public ContainerAnalysisV1Beta1Stub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ContainerAnalysisV1Beta1Stub(channel, callOptions);
+          }
+        };
+    return ContainerAnalysisV1Beta1Stub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ContainerAnalysisV1Beta1BlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ContainerAnalysisV1Beta1BlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ContainerAnalysisV1Beta1BlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ContainerAnalysisV1Beta1BlockingStub>() {
+          @java.lang.Override
+          public ContainerAnalysisV1Beta1BlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ContainerAnalysisV1Beta1BlockingStub(channel, callOptions);
+          }
+        };
+    return ContainerAnalysisV1Beta1BlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ContainerAnalysisV1Beta1FutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ContainerAnalysisV1Beta1FutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ContainerAnalysisV1Beta1FutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ContainerAnalysisV1Beta1FutureStub>() {
+          @java.lang.Override
+          public ContainerAnalysisV1Beta1FutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ContainerAnalysisV1Beta1FutureStub(channel, callOptions);
+          }
+        };
+    return ContainerAnalysisV1Beta1FutureStub.newStub(factory, channel);
   }
 
   /**
@@ -442,7 +394,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
     public void setIamPolicy(
         com.google.iam.v1.SetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
-      asyncUnimplementedUnaryCall(getSetIamPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSetIamPolicyMethod(), responseObserver);
     }
 
     /**
@@ -461,7 +413,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
     public void getIamPolicy(
         com.google.iam.v1.GetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetIamPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetIamPolicyMethod(), responseObserver);
     }
 
     /**
@@ -480,7 +432,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
         com.google.iam.v1.TestIamPermissionsRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.TestIamPermissionsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getTestIamPermissionsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getTestIamPermissionsMethod(), responseObserver);
     }
 
     /**
@@ -494,7 +446,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
         com.google.containeranalysis.v1beta1.GetScanConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.containeranalysis.v1beta1.ScanConfig>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetScanConfigMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetScanConfigMethod(), responseObserver);
     }
 
     /**
@@ -508,7 +460,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
         com.google.containeranalysis.v1beta1.ListScanConfigsRequest request,
         io.grpc.stub.StreamObserver<com.google.containeranalysis.v1beta1.ListScanConfigsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListScanConfigsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListScanConfigsMethod(), responseObserver);
     }
 
     /**
@@ -522,47 +474,47 @@ public final class ContainerAnalysisV1Beta1Grpc {
         com.google.containeranalysis.v1beta1.UpdateScanConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.containeranalysis.v1beta1.ScanConfig>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateScanConfigMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateScanConfigMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getSetIamPolicyMethodHelper(),
+              getSetIamPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>(
                       this, METHODID_SET_IAM_POLICY)))
           .addMethod(
-              getGetIamPolicyMethodHelper(),
+              getGetIamPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>(
                       this, METHODID_GET_IAM_POLICY)))
           .addMethod(
-              getTestIamPermissionsMethodHelper(),
+              getTestIamPermissionsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.TestIamPermissionsRequest,
                       com.google.iam.v1.TestIamPermissionsResponse>(
                       this, METHODID_TEST_IAM_PERMISSIONS)))
           .addMethod(
-              getGetScanConfigMethodHelper(),
+              getGetScanConfigMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.containeranalysis.v1beta1.GetScanConfigRequest,
                       com.google.containeranalysis.v1beta1.ScanConfig>(
                       this, METHODID_GET_SCAN_CONFIG)))
           .addMethod(
-              getListScanConfigsMethodHelper(),
+              getListScanConfigsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.containeranalysis.v1beta1.ListScanConfigsRequest,
                       com.google.containeranalysis.v1beta1.ListScanConfigsResponse>(
                       this, METHODID_LIST_SCAN_CONFIGS)))
           .addMethod(
-              getUpdateScanConfigMethodHelper(),
+              getUpdateScanConfigMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.containeranalysis.v1beta1.UpdateScanConfigRequest,
@@ -590,11 +542,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
    * </pre>
    */
   public static final class ContainerAnalysisV1Beta1Stub
-      extends io.grpc.stub.AbstractStub<ContainerAnalysisV1Beta1Stub> {
-    private ContainerAnalysisV1Beta1Stub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<ContainerAnalysisV1Beta1Stub> {
     private ContainerAnalysisV1Beta1Stub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -622,7 +570,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
         com.google.iam.v1.SetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSetIamPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getSetIamPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -644,7 +592,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
         com.google.iam.v1.GetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetIamPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetIamPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -666,7 +614,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
         io.grpc.stub.StreamObserver<com.google.iam.v1.TestIamPermissionsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getTestIamPermissionsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getTestIamPermissionsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -683,7 +631,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
         io.grpc.stub.StreamObserver<com.google.containeranalysis.v1beta1.ScanConfig>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetScanConfigMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetScanConfigMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -700,7 +648,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
         io.grpc.stub.StreamObserver<com.google.containeranalysis.v1beta1.ListScanConfigsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListScanConfigsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListScanConfigsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -717,7 +665,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
         io.grpc.stub.StreamObserver<com.google.containeranalysis.v1beta1.ScanConfig>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateScanConfigMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateScanConfigMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -741,11 +689,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
    * </pre>
    */
   public static final class ContainerAnalysisV1Beta1BlockingStub
-      extends io.grpc.stub.AbstractStub<ContainerAnalysisV1Beta1BlockingStub> {
-    private ContainerAnalysisV1Beta1BlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ContainerAnalysisV1Beta1BlockingStub> {
     private ContainerAnalysisV1Beta1BlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -771,8 +715,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
      * </pre>
      */
     public com.google.iam.v1.Policy setIamPolicy(com.google.iam.v1.SetIamPolicyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getSetIamPolicyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSetIamPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -789,8 +732,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
      * </pre>
      */
     public com.google.iam.v1.Policy getIamPolicy(com.google.iam.v1.GetIamPolicyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetIamPolicyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetIamPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -808,7 +750,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
     public com.google.iam.v1.TestIamPermissionsResponse testIamPermissions(
         com.google.iam.v1.TestIamPermissionsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getTestIamPermissionsMethodHelper(), getCallOptions(), request);
+          getChannel(), getTestIamPermissionsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -820,8 +762,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
      */
     public com.google.containeranalysis.v1beta1.ScanConfig getScanConfig(
         com.google.containeranalysis.v1beta1.GetScanConfigRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetScanConfigMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetScanConfigMethod(), getCallOptions(), request);
     }
 
     /**
@@ -833,8 +774,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
      */
     public com.google.containeranalysis.v1beta1.ListScanConfigsResponse listScanConfigs(
         com.google.containeranalysis.v1beta1.ListScanConfigsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListScanConfigsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListScanConfigsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -847,7 +787,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
     public com.google.containeranalysis.v1beta1.ScanConfig updateScanConfig(
         com.google.containeranalysis.v1beta1.UpdateScanConfigRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateScanConfigMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateScanConfigMethod(), getCallOptions(), request);
     }
   }
 
@@ -869,11 +809,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
    * </pre>
    */
   public static final class ContainerAnalysisV1Beta1FutureStub
-      extends io.grpc.stub.AbstractStub<ContainerAnalysisV1Beta1FutureStub> {
-    private ContainerAnalysisV1Beta1FutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ContainerAnalysisV1Beta1FutureStub> {
     private ContainerAnalysisV1Beta1FutureStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -901,7 +837,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.iam.v1.Policy>
         setIamPolicy(com.google.iam.v1.SetIamPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getSetIamPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getSetIamPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -920,7 +856,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.iam.v1.Policy>
         getIamPolicy(com.google.iam.v1.GetIamPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetIamPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetIamPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -939,7 +875,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
             com.google.iam.v1.TestIamPermissionsResponse>
         testIamPermissions(com.google.iam.v1.TestIamPermissionsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getTestIamPermissionsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getTestIamPermissionsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -953,7 +889,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
             com.google.containeranalysis.v1beta1.ScanConfig>
         getScanConfig(com.google.containeranalysis.v1beta1.GetScanConfigRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetScanConfigMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetScanConfigMethod(), getCallOptions()), request);
     }
 
     /**
@@ -967,7 +903,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
             com.google.containeranalysis.v1beta1.ListScanConfigsResponse>
         listScanConfigs(com.google.containeranalysis.v1beta1.ListScanConfigsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListScanConfigsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListScanConfigsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -981,7 +917,7 @@ public final class ContainerAnalysisV1Beta1Grpc {
             com.google.containeranalysis.v1beta1.ScanConfig>
         updateScanConfig(com.google.containeranalysis.v1beta1.UpdateScanConfigRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateScanConfigMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateScanConfigMethod(), getCallOptions()), request);
     }
   }
 
@@ -1108,12 +1044,12 @@ public final class ContainerAnalysisV1Beta1Grpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ContainerAnalysisV1Beta1FileDescriptorSupplier())
-                      .addMethod(getSetIamPolicyMethodHelper())
-                      .addMethod(getGetIamPolicyMethodHelper())
-                      .addMethod(getTestIamPermissionsMethodHelper())
-                      .addMethod(getGetScanConfigMethodHelper())
-                      .addMethod(getListScanConfigsMethodHelper())
-                      .addMethod(getUpdateScanConfigMethodHelper())
+                      .addMethod(getSetIamPolicyMethod())
+                      .addMethod(getGetIamPolicyMethod())
+                      .addMethod(getTestIamPermissionsMethod())
+                      .addMethod(getGetScanConfigMethod())
+                      .addMethod(getListScanConfigsMethod())
+                      .addMethod(getUpdateScanConfigMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-containeranalysis-v1beta1/src/main/java/io/grafeas/v1beta1/GrafeasV1Beta1Grpc.java
+++ b/grpc-google-cloud-containeranalysis-v1beta1/src/main/java/io/grafeas/v1beta1/GrafeasV1Beta1Grpc.java
@@ -40,7 +40,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/devtools/containeranalysis/v1beta1/grafeas/grafeas.proto")
 public final class GrafeasV1Beta1Grpc {
 
@@ -49,26 +49,18 @@ public final class GrafeasV1Beta1Grpc {
   public static final String SERVICE_NAME = "grafeas.v1beta1.GrafeasV1Beta1";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetOccurrenceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.GetOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
-      METHOD_GET_OCCURRENCE = getGetOccurrenceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.GetOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
       getGetOccurrenceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetOccurrence",
+      requestType = io.grafeas.v1beta1.GetOccurrenceRequest.class,
+      responseType = io.grafeas.v1beta1.Occurrence.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.GetOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
       getGetOccurrenceMethod() {
-    return getGetOccurrenceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.GetOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
-      getGetOccurrenceMethodHelper() {
     io.grpc.MethodDescriptor<io.grafeas.v1beta1.GetOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
         getGetOccurrenceMethod;
     if ((getGetOccurrenceMethod = GrafeasV1Beta1Grpc.getGetOccurrenceMethod) == null) {
@@ -80,8 +72,7 @@ public final class GrafeasV1Beta1Grpc {
                       .<io.grafeas.v1beta1.GetOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("grafeas.v1beta1.GrafeasV1Beta1", "GetOccurrence"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetOccurrence"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -98,26 +89,18 @@ public final class GrafeasV1Beta1Grpc {
     return getGetOccurrenceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListOccurrencesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.ListOccurrencesRequest, io.grafeas.v1beta1.ListOccurrencesResponse>
-      METHOD_LIST_OCCURRENCES = getListOccurrencesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.ListOccurrencesRequest, io.grafeas.v1beta1.ListOccurrencesResponse>
       getListOccurrencesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListOccurrences",
+      requestType = io.grafeas.v1beta1.ListOccurrencesRequest.class,
+      responseType = io.grafeas.v1beta1.ListOccurrencesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.ListOccurrencesRequest, io.grafeas.v1beta1.ListOccurrencesResponse>
       getListOccurrencesMethod() {
-    return getListOccurrencesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.ListOccurrencesRequest, io.grafeas.v1beta1.ListOccurrencesResponse>
-      getListOccurrencesMethodHelper() {
     io.grpc.MethodDescriptor<
             io.grafeas.v1beta1.ListOccurrencesRequest, io.grafeas.v1beta1.ListOccurrencesResponse>
         getListOccurrencesMethod;
@@ -131,9 +114,7 @@ public final class GrafeasV1Beta1Grpc {
                           io.grafeas.v1beta1.ListOccurrencesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "grafeas.v1beta1.GrafeasV1Beta1", "ListOccurrences"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListOccurrences"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -150,26 +131,18 @@ public final class GrafeasV1Beta1Grpc {
     return getListOccurrencesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteOccurrenceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.DeleteOccurrenceRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_OCCURRENCE = getDeleteOccurrenceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.DeleteOccurrenceRequest, com.google.protobuf.Empty>
       getDeleteOccurrenceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteOccurrence",
+      requestType = io.grafeas.v1beta1.DeleteOccurrenceRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.DeleteOccurrenceRequest, com.google.protobuf.Empty>
       getDeleteOccurrenceMethod() {
-    return getDeleteOccurrenceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.DeleteOccurrenceRequest, com.google.protobuf.Empty>
-      getDeleteOccurrenceMethodHelper() {
     io.grpc.MethodDescriptor<io.grafeas.v1beta1.DeleteOccurrenceRequest, com.google.protobuf.Empty>
         getDeleteOccurrenceMethod;
     if ((getDeleteOccurrenceMethod = GrafeasV1Beta1Grpc.getDeleteOccurrenceMethod) == null) {
@@ -181,9 +154,7 @@ public final class GrafeasV1Beta1Grpc {
                       .<io.grafeas.v1beta1.DeleteOccurrenceRequest, com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "grafeas.v1beta1.GrafeasV1Beta1", "DeleteOccurrence"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteOccurrence"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -200,26 +171,18 @@ public final class GrafeasV1Beta1Grpc {
     return getDeleteOccurrenceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateOccurrenceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.CreateOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
-      METHOD_CREATE_OCCURRENCE = getCreateOccurrenceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.CreateOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
       getCreateOccurrenceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateOccurrence",
+      requestType = io.grafeas.v1beta1.CreateOccurrenceRequest.class,
+      responseType = io.grafeas.v1beta1.Occurrence.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.CreateOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
       getCreateOccurrenceMethod() {
-    return getCreateOccurrenceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.CreateOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
-      getCreateOccurrenceMethodHelper() {
     io.grpc.MethodDescriptor<
             io.grafeas.v1beta1.CreateOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
         getCreateOccurrenceMethod;
@@ -232,9 +195,7 @@ public final class GrafeasV1Beta1Grpc {
                       .<io.grafeas.v1beta1.CreateOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "grafeas.v1beta1.GrafeasV1Beta1", "CreateOccurrence"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateOccurrence"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -251,30 +212,20 @@ public final class GrafeasV1Beta1Grpc {
     return getCreateOccurrenceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchCreateOccurrencesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.BatchCreateOccurrencesRequest,
-          io.grafeas.v1beta1.BatchCreateOccurrencesResponse>
-      METHOD_BATCH_CREATE_OCCURRENCES = getBatchCreateOccurrencesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.BatchCreateOccurrencesRequest,
           io.grafeas.v1beta1.BatchCreateOccurrencesResponse>
       getBatchCreateOccurrencesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchCreateOccurrences",
+      requestType = io.grafeas.v1beta1.BatchCreateOccurrencesRequest.class,
+      responseType = io.grafeas.v1beta1.BatchCreateOccurrencesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.BatchCreateOccurrencesRequest,
           io.grafeas.v1beta1.BatchCreateOccurrencesResponse>
       getBatchCreateOccurrencesMethod() {
-    return getBatchCreateOccurrencesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.BatchCreateOccurrencesRequest,
-          io.grafeas.v1beta1.BatchCreateOccurrencesResponse>
-      getBatchCreateOccurrencesMethodHelper() {
     io.grpc.MethodDescriptor<
             io.grafeas.v1beta1.BatchCreateOccurrencesRequest,
             io.grafeas.v1beta1.BatchCreateOccurrencesResponse>
@@ -292,8 +243,7 @@ public final class GrafeasV1Beta1Grpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "grafeas.v1beta1.GrafeasV1Beta1", "BatchCreateOccurrences"))
+                          generateFullMethodName(SERVICE_NAME, "BatchCreateOccurrences"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -312,26 +262,18 @@ public final class GrafeasV1Beta1Grpc {
     return getBatchCreateOccurrencesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateOccurrenceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.UpdateOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
-      METHOD_UPDATE_OCCURRENCE = getUpdateOccurrenceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.UpdateOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
       getUpdateOccurrenceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateOccurrence",
+      requestType = io.grafeas.v1beta1.UpdateOccurrenceRequest.class,
+      responseType = io.grafeas.v1beta1.Occurrence.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.UpdateOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
       getUpdateOccurrenceMethod() {
-    return getUpdateOccurrenceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.UpdateOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
-      getUpdateOccurrenceMethodHelper() {
     io.grpc.MethodDescriptor<
             io.grafeas.v1beta1.UpdateOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
         getUpdateOccurrenceMethod;
@@ -344,9 +286,7 @@ public final class GrafeasV1Beta1Grpc {
                       .<io.grafeas.v1beta1.UpdateOccurrenceRequest, io.grafeas.v1beta1.Occurrence>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "grafeas.v1beta1.GrafeasV1Beta1", "UpdateOccurrence"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateOccurrence"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -363,26 +303,18 @@ public final class GrafeasV1Beta1Grpc {
     return getUpdateOccurrenceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetOccurrenceNoteMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.GetOccurrenceNoteRequest, io.grafeas.v1beta1.Note>
-      METHOD_GET_OCCURRENCE_NOTE = getGetOccurrenceNoteMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.GetOccurrenceNoteRequest, io.grafeas.v1beta1.Note>
       getGetOccurrenceNoteMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetOccurrenceNote",
+      requestType = io.grafeas.v1beta1.GetOccurrenceNoteRequest.class,
+      responseType = io.grafeas.v1beta1.Note.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.GetOccurrenceNoteRequest, io.grafeas.v1beta1.Note>
       getGetOccurrenceNoteMethod() {
-    return getGetOccurrenceNoteMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.GetOccurrenceNoteRequest, io.grafeas.v1beta1.Note>
-      getGetOccurrenceNoteMethodHelper() {
     io.grpc.MethodDescriptor<io.grafeas.v1beta1.GetOccurrenceNoteRequest, io.grafeas.v1beta1.Note>
         getGetOccurrenceNoteMethod;
     if ((getGetOccurrenceNoteMethod = GrafeasV1Beta1Grpc.getGetOccurrenceNoteMethod) == null) {
@@ -394,9 +326,7 @@ public final class GrafeasV1Beta1Grpc {
                       .<io.grafeas.v1beta1.GetOccurrenceNoteRequest, io.grafeas.v1beta1.Note>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "grafeas.v1beta1.GrafeasV1Beta1", "GetOccurrenceNote"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetOccurrenceNote"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -413,25 +343,17 @@ public final class GrafeasV1Beta1Grpc {
     return getGetOccurrenceNoteMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetNoteMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.GetNoteRequest, io.grafeas.v1beta1.Note>
-      METHOD_GET_NOTE = getGetNoteMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.GetNoteRequest, io.grafeas.v1beta1.Note>
       getGetNoteMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetNote",
+      requestType = io.grafeas.v1beta1.GetNoteRequest.class,
+      responseType = io.grafeas.v1beta1.Note.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<io.grafeas.v1beta1.GetNoteRequest, io.grafeas.v1beta1.Note>
       getGetNoteMethod() {
-    return getGetNoteMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.GetNoteRequest, io.grafeas.v1beta1.Note>
-      getGetNoteMethodHelper() {
     io.grpc.MethodDescriptor<io.grafeas.v1beta1.GetNoteRequest, io.grafeas.v1beta1.Note>
         getGetNoteMethod;
     if ((getGetNoteMethod = GrafeasV1Beta1Grpc.getGetNoteMethod) == null) {
@@ -442,8 +364,7 @@ public final class GrafeasV1Beta1Grpc {
                   io.grpc.MethodDescriptor
                       .<io.grafeas.v1beta1.GetNoteRequest, io.grafeas.v1beta1.Note>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("grafeas.v1beta1.GrafeasV1Beta1", "GetNote"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetNote"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -459,26 +380,18 @@ public final class GrafeasV1Beta1Grpc {
     return getGetNoteMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListNotesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.ListNotesRequest, io.grafeas.v1beta1.ListNotesResponse>
-      METHOD_LIST_NOTES = getListNotesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.ListNotesRequest, io.grafeas.v1beta1.ListNotesResponse>
       getListNotesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListNotes",
+      requestType = io.grafeas.v1beta1.ListNotesRequest.class,
+      responseType = io.grafeas.v1beta1.ListNotesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.ListNotesRequest, io.grafeas.v1beta1.ListNotesResponse>
       getListNotesMethod() {
-    return getListNotesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.ListNotesRequest, io.grafeas.v1beta1.ListNotesResponse>
-      getListNotesMethodHelper() {
     io.grpc.MethodDescriptor<
             io.grafeas.v1beta1.ListNotesRequest, io.grafeas.v1beta1.ListNotesResponse>
         getListNotesMethod;
@@ -491,8 +404,7 @@ public final class GrafeasV1Beta1Grpc {
                       .<io.grafeas.v1beta1.ListNotesRequest, io.grafeas.v1beta1.ListNotesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("grafeas.v1beta1.GrafeasV1Beta1", "ListNotes"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListNotes"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -508,26 +420,18 @@ public final class GrafeasV1Beta1Grpc {
     return getListNotesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteNoteMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.DeleteNoteRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_NOTE = getDeleteNoteMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.DeleteNoteRequest, com.google.protobuf.Empty>
       getDeleteNoteMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteNote",
+      requestType = io.grafeas.v1beta1.DeleteNoteRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.DeleteNoteRequest, com.google.protobuf.Empty>
       getDeleteNoteMethod() {
-    return getDeleteNoteMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.DeleteNoteRequest, com.google.protobuf.Empty>
-      getDeleteNoteMethodHelper() {
     io.grpc.MethodDescriptor<io.grafeas.v1beta1.DeleteNoteRequest, com.google.protobuf.Empty>
         getDeleteNoteMethod;
     if ((getDeleteNoteMethod = GrafeasV1Beta1Grpc.getDeleteNoteMethod) == null) {
@@ -538,8 +442,7 @@ public final class GrafeasV1Beta1Grpc {
                   io.grpc.MethodDescriptor
                       .<io.grafeas.v1beta1.DeleteNoteRequest, com.google.protobuf.Empty>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("grafeas.v1beta1.GrafeasV1Beta1", "DeleteNote"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteNote"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -555,26 +458,18 @@ public final class GrafeasV1Beta1Grpc {
     return getDeleteNoteMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateNoteMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.CreateNoteRequest, io.grafeas.v1beta1.Note>
-      METHOD_CREATE_NOTE = getCreateNoteMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.CreateNoteRequest, io.grafeas.v1beta1.Note>
       getCreateNoteMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateNote",
+      requestType = io.grafeas.v1beta1.CreateNoteRequest.class,
+      responseType = io.grafeas.v1beta1.Note.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.CreateNoteRequest, io.grafeas.v1beta1.Note>
       getCreateNoteMethod() {
-    return getCreateNoteMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.CreateNoteRequest, io.grafeas.v1beta1.Note>
-      getCreateNoteMethodHelper() {
     io.grpc.MethodDescriptor<io.grafeas.v1beta1.CreateNoteRequest, io.grafeas.v1beta1.Note>
         getCreateNoteMethod;
     if ((getCreateNoteMethod = GrafeasV1Beta1Grpc.getCreateNoteMethod) == null) {
@@ -585,8 +480,7 @@ public final class GrafeasV1Beta1Grpc {
                   io.grpc.MethodDescriptor
                       .<io.grafeas.v1beta1.CreateNoteRequest, io.grafeas.v1beta1.Note>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("grafeas.v1beta1.GrafeasV1Beta1", "CreateNote"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateNote"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -602,26 +496,18 @@ public final class GrafeasV1Beta1Grpc {
     return getCreateNoteMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchCreateNotesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.BatchCreateNotesRequest, io.grafeas.v1beta1.BatchCreateNotesResponse>
-      METHOD_BATCH_CREATE_NOTES = getBatchCreateNotesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.BatchCreateNotesRequest, io.grafeas.v1beta1.BatchCreateNotesResponse>
       getBatchCreateNotesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchCreateNotes",
+      requestType = io.grafeas.v1beta1.BatchCreateNotesRequest.class,
+      responseType = io.grafeas.v1beta1.BatchCreateNotesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.BatchCreateNotesRequest, io.grafeas.v1beta1.BatchCreateNotesResponse>
       getBatchCreateNotesMethod() {
-    return getBatchCreateNotesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.BatchCreateNotesRequest, io.grafeas.v1beta1.BatchCreateNotesResponse>
-      getBatchCreateNotesMethodHelper() {
     io.grpc.MethodDescriptor<
             io.grafeas.v1beta1.BatchCreateNotesRequest, io.grafeas.v1beta1.BatchCreateNotesResponse>
         getBatchCreateNotesMethod;
@@ -635,9 +521,7 @@ public final class GrafeasV1Beta1Grpc {
                           io.grafeas.v1beta1.BatchCreateNotesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "grafeas.v1beta1.GrafeasV1Beta1", "BatchCreateNotes"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "BatchCreateNotes"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -654,26 +538,18 @@ public final class GrafeasV1Beta1Grpc {
     return getBatchCreateNotesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateNoteMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.UpdateNoteRequest, io.grafeas.v1beta1.Note>
-      METHOD_UPDATE_NOTE = getUpdateNoteMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.UpdateNoteRequest, io.grafeas.v1beta1.Note>
       getUpdateNoteMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateNote",
+      requestType = io.grafeas.v1beta1.UpdateNoteRequest.class,
+      responseType = io.grafeas.v1beta1.Note.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.UpdateNoteRequest, io.grafeas.v1beta1.Note>
       getUpdateNoteMethod() {
-    return getUpdateNoteMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.UpdateNoteRequest, io.grafeas.v1beta1.Note>
-      getUpdateNoteMethodHelper() {
     io.grpc.MethodDescriptor<io.grafeas.v1beta1.UpdateNoteRequest, io.grafeas.v1beta1.Note>
         getUpdateNoteMethod;
     if ((getUpdateNoteMethod = GrafeasV1Beta1Grpc.getUpdateNoteMethod) == null) {
@@ -684,8 +560,7 @@ public final class GrafeasV1Beta1Grpc {
                   io.grpc.MethodDescriptor
                       .<io.grafeas.v1beta1.UpdateNoteRequest, io.grafeas.v1beta1.Note>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("grafeas.v1beta1.GrafeasV1Beta1", "UpdateNote"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateNote"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -701,30 +576,20 @@ public final class GrafeasV1Beta1Grpc {
     return getUpdateNoteMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListNoteOccurrencesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.ListNoteOccurrencesRequest,
-          io.grafeas.v1beta1.ListNoteOccurrencesResponse>
-      METHOD_LIST_NOTE_OCCURRENCES = getListNoteOccurrencesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.ListNoteOccurrencesRequest,
           io.grafeas.v1beta1.ListNoteOccurrencesResponse>
       getListNoteOccurrencesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListNoteOccurrences",
+      requestType = io.grafeas.v1beta1.ListNoteOccurrencesRequest.class,
+      responseType = io.grafeas.v1beta1.ListNoteOccurrencesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.ListNoteOccurrencesRequest,
           io.grafeas.v1beta1.ListNoteOccurrencesResponse>
       getListNoteOccurrencesMethod() {
-    return getListNoteOccurrencesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.ListNoteOccurrencesRequest,
-          io.grafeas.v1beta1.ListNoteOccurrencesResponse>
-      getListNoteOccurrencesMethodHelper() {
     io.grpc.MethodDescriptor<
             io.grafeas.v1beta1.ListNoteOccurrencesRequest,
             io.grafeas.v1beta1.ListNoteOccurrencesResponse>
@@ -741,8 +606,7 @@ public final class GrafeasV1Beta1Grpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "grafeas.v1beta1.GrafeasV1Beta1", "ListNoteOccurrences"))
+                          generateFullMethodName(SERVICE_NAME, "ListNoteOccurrences"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -759,31 +623,20 @@ public final class GrafeasV1Beta1Grpc {
     return getListNoteOccurrencesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetVulnerabilityOccurrencesSummaryMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.GetVulnerabilityOccurrencesSummaryRequest,
-          io.grafeas.v1beta1.VulnerabilityOccurrencesSummary>
-      METHOD_GET_VULNERABILITY_OCCURRENCES_SUMMARY =
-          getGetVulnerabilityOccurrencesSummaryMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.GetVulnerabilityOccurrencesSummaryRequest,
           io.grafeas.v1beta1.VulnerabilityOccurrencesSummary>
       getGetVulnerabilityOccurrencesSummaryMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetVulnerabilityOccurrencesSummary",
+      requestType = io.grafeas.v1beta1.GetVulnerabilityOccurrencesSummaryRequest.class,
+      responseType = io.grafeas.v1beta1.VulnerabilityOccurrencesSummary.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           io.grafeas.v1beta1.GetVulnerabilityOccurrencesSummaryRequest,
           io.grafeas.v1beta1.VulnerabilityOccurrencesSummary>
       getGetVulnerabilityOccurrencesSummaryMethod() {
-    return getGetVulnerabilityOccurrencesSummaryMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          io.grafeas.v1beta1.GetVulnerabilityOccurrencesSummaryRequest,
-          io.grafeas.v1beta1.VulnerabilityOccurrencesSummary>
-      getGetVulnerabilityOccurrencesSummaryMethodHelper() {
     io.grpc.MethodDescriptor<
             io.grafeas.v1beta1.GetVulnerabilityOccurrencesSummaryRequest,
             io.grafeas.v1beta1.VulnerabilityOccurrencesSummary>
@@ -804,8 +657,7 @@ public final class GrafeasV1Beta1Grpc {
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
                           generateFullMethodName(
-                              "grafeas.v1beta1.GrafeasV1Beta1",
-                              "GetVulnerabilityOccurrencesSummary"))
+                              SERVICE_NAME, "GetVulnerabilityOccurrencesSummary"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -827,19 +679,43 @@ public final class GrafeasV1Beta1Grpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static GrafeasV1Beta1Stub newStub(io.grpc.Channel channel) {
-    return new GrafeasV1Beta1Stub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<GrafeasV1Beta1Stub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<GrafeasV1Beta1Stub>() {
+          @java.lang.Override
+          public GrafeasV1Beta1Stub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new GrafeasV1Beta1Stub(channel, callOptions);
+          }
+        };
+    return GrafeasV1Beta1Stub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static GrafeasV1Beta1BlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new GrafeasV1Beta1BlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<GrafeasV1Beta1BlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<GrafeasV1Beta1BlockingStub>() {
+          @java.lang.Override
+          public GrafeasV1Beta1BlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new GrafeasV1Beta1BlockingStub(channel, callOptions);
+          }
+        };
+    return GrafeasV1Beta1BlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static GrafeasV1Beta1FutureStub newFutureStub(io.grpc.Channel channel) {
-    return new GrafeasV1Beta1FutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<GrafeasV1Beta1FutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<GrafeasV1Beta1FutureStub>() {
+          @java.lang.Override
+          public GrafeasV1Beta1FutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new GrafeasV1Beta1FutureStub(channel, callOptions);
+          }
+        };
+    return GrafeasV1Beta1FutureStub.newStub(factory, channel);
   }
 
   /**
@@ -871,7 +747,7 @@ public final class GrafeasV1Beta1Grpc {
     public void getOccurrence(
         io.grafeas.v1beta1.GetOccurrenceRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.Occurrence> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetOccurrenceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetOccurrenceMethod(), responseObserver);
     }
 
     /**
@@ -884,7 +760,7 @@ public final class GrafeasV1Beta1Grpc {
     public void listOccurrences(
         io.grafeas.v1beta1.ListOccurrencesRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.ListOccurrencesResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getListOccurrencesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListOccurrencesMethod(), responseObserver);
     }
 
     /**
@@ -899,7 +775,7 @@ public final class GrafeasV1Beta1Grpc {
     public void deleteOccurrence(
         io.grafeas.v1beta1.DeleteOccurrenceRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteOccurrenceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteOccurrenceMethod(), responseObserver);
     }
 
     /**
@@ -912,7 +788,7 @@ public final class GrafeasV1Beta1Grpc {
     public void createOccurrence(
         io.grafeas.v1beta1.CreateOccurrenceRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.Occurrence> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateOccurrenceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateOccurrenceMethod(), responseObserver);
     }
 
     /**
@@ -926,7 +802,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grafeas.v1beta1.BatchCreateOccurrencesRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.BatchCreateOccurrencesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchCreateOccurrencesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchCreateOccurrencesMethod(), responseObserver);
     }
 
     /**
@@ -939,7 +815,7 @@ public final class GrafeasV1Beta1Grpc {
     public void updateOccurrence(
         io.grafeas.v1beta1.UpdateOccurrenceRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.Occurrence> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateOccurrenceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateOccurrenceMethod(), responseObserver);
     }
 
     /**
@@ -953,7 +829,7 @@ public final class GrafeasV1Beta1Grpc {
     public void getOccurrenceNote(
         io.grafeas.v1beta1.GetOccurrenceNoteRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.Note> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetOccurrenceNoteMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetOccurrenceNoteMethod(), responseObserver);
     }
 
     /**
@@ -966,7 +842,7 @@ public final class GrafeasV1Beta1Grpc {
     public void getNote(
         io.grafeas.v1beta1.GetNoteRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.Note> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetNoteMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetNoteMethod(), responseObserver);
     }
 
     /**
@@ -979,7 +855,7 @@ public final class GrafeasV1Beta1Grpc {
     public void listNotes(
         io.grafeas.v1beta1.ListNotesRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.ListNotesResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getListNotesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListNotesMethod(), responseObserver);
     }
 
     /**
@@ -992,7 +868,7 @@ public final class GrafeasV1Beta1Grpc {
     public void deleteNote(
         io.grafeas.v1beta1.DeleteNoteRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteNoteMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteNoteMethod(), responseObserver);
     }
 
     /**
@@ -1005,7 +881,7 @@ public final class GrafeasV1Beta1Grpc {
     public void createNote(
         io.grafeas.v1beta1.CreateNoteRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.Note> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateNoteMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateNoteMethod(), responseObserver);
     }
 
     /**
@@ -1018,7 +894,7 @@ public final class GrafeasV1Beta1Grpc {
     public void batchCreateNotes(
         io.grafeas.v1beta1.BatchCreateNotesRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.BatchCreateNotesResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchCreateNotesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchCreateNotesMethod(), responseObserver);
     }
 
     /**
@@ -1031,7 +907,7 @@ public final class GrafeasV1Beta1Grpc {
     public void updateNote(
         io.grafeas.v1beta1.UpdateNoteRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.Note> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateNoteMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateNoteMethod(), responseObserver);
     }
 
     /**
@@ -1047,7 +923,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grafeas.v1beta1.ListNoteOccurrencesRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.ListNoteOccurrencesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListNoteOccurrencesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListNoteOccurrencesMethod(), responseObserver);
     }
 
     /**
@@ -1061,99 +937,98 @@ public final class GrafeasV1Beta1Grpc {
         io.grafeas.v1beta1.GetVulnerabilityOccurrencesSummaryRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.VulnerabilityOccurrencesSummary>
             responseObserver) {
-      asyncUnimplementedUnaryCall(
-          getGetVulnerabilityOccurrencesSummaryMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetVulnerabilityOccurrencesSummaryMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getGetOccurrenceMethodHelper(),
+              getGetOccurrenceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       io.grafeas.v1beta1.GetOccurrenceRequest, io.grafeas.v1beta1.Occurrence>(
                       this, METHODID_GET_OCCURRENCE)))
           .addMethod(
-              getListOccurrencesMethodHelper(),
+              getListOccurrencesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       io.grafeas.v1beta1.ListOccurrencesRequest,
                       io.grafeas.v1beta1.ListOccurrencesResponse>(this, METHODID_LIST_OCCURRENCES)))
           .addMethod(
-              getDeleteOccurrenceMethodHelper(),
+              getDeleteOccurrenceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       io.grafeas.v1beta1.DeleteOccurrenceRequest, com.google.protobuf.Empty>(
                       this, METHODID_DELETE_OCCURRENCE)))
           .addMethod(
-              getCreateOccurrenceMethodHelper(),
+              getCreateOccurrenceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       io.grafeas.v1beta1.CreateOccurrenceRequest, io.grafeas.v1beta1.Occurrence>(
                       this, METHODID_CREATE_OCCURRENCE)))
           .addMethod(
-              getBatchCreateOccurrencesMethodHelper(),
+              getBatchCreateOccurrencesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       io.grafeas.v1beta1.BatchCreateOccurrencesRequest,
                       io.grafeas.v1beta1.BatchCreateOccurrencesResponse>(
                       this, METHODID_BATCH_CREATE_OCCURRENCES)))
           .addMethod(
-              getUpdateOccurrenceMethodHelper(),
+              getUpdateOccurrenceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       io.grafeas.v1beta1.UpdateOccurrenceRequest, io.grafeas.v1beta1.Occurrence>(
                       this, METHODID_UPDATE_OCCURRENCE)))
           .addMethod(
-              getGetOccurrenceNoteMethodHelper(),
+              getGetOccurrenceNoteMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       io.grafeas.v1beta1.GetOccurrenceNoteRequest, io.grafeas.v1beta1.Note>(
                       this, METHODID_GET_OCCURRENCE_NOTE)))
           .addMethod(
-              getGetNoteMethodHelper(),
+              getGetNoteMethod(),
               asyncUnaryCall(
                   new MethodHandlers<io.grafeas.v1beta1.GetNoteRequest, io.grafeas.v1beta1.Note>(
                       this, METHODID_GET_NOTE)))
           .addMethod(
-              getListNotesMethodHelper(),
+              getListNotesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       io.grafeas.v1beta1.ListNotesRequest, io.grafeas.v1beta1.ListNotesResponse>(
                       this, METHODID_LIST_NOTES)))
           .addMethod(
-              getDeleteNoteMethodHelper(),
+              getDeleteNoteMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       io.grafeas.v1beta1.DeleteNoteRequest, com.google.protobuf.Empty>(
                       this, METHODID_DELETE_NOTE)))
           .addMethod(
-              getCreateNoteMethodHelper(),
+              getCreateNoteMethod(),
               asyncUnaryCall(
                   new MethodHandlers<io.grafeas.v1beta1.CreateNoteRequest, io.grafeas.v1beta1.Note>(
                       this, METHODID_CREATE_NOTE)))
           .addMethod(
-              getBatchCreateNotesMethodHelper(),
+              getBatchCreateNotesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       io.grafeas.v1beta1.BatchCreateNotesRequest,
                       io.grafeas.v1beta1.BatchCreateNotesResponse>(
                       this, METHODID_BATCH_CREATE_NOTES)))
           .addMethod(
-              getUpdateNoteMethodHelper(),
+              getUpdateNoteMethod(),
               asyncUnaryCall(
                   new MethodHandlers<io.grafeas.v1beta1.UpdateNoteRequest, io.grafeas.v1beta1.Note>(
                       this, METHODID_UPDATE_NOTE)))
           .addMethod(
-              getListNoteOccurrencesMethodHelper(),
+              getListNoteOccurrencesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       io.grafeas.v1beta1.ListNoteOccurrencesRequest,
                       io.grafeas.v1beta1.ListNoteOccurrencesResponse>(
                       this, METHODID_LIST_NOTE_OCCURRENCES)))
           .addMethod(
-              getGetVulnerabilityOccurrencesSummaryMethodHelper(),
+              getGetVulnerabilityOccurrencesSummaryMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       io.grafeas.v1beta1.GetVulnerabilityOccurrencesSummaryRequest,
@@ -1181,11 +1056,7 @@ public final class GrafeasV1Beta1Grpc {
    * </pre>
    */
   public static final class GrafeasV1Beta1Stub
-      extends io.grpc.stub.AbstractStub<GrafeasV1Beta1Stub> {
-    private GrafeasV1Beta1Stub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<GrafeasV1Beta1Stub> {
     private GrafeasV1Beta1Stub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1206,7 +1077,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grafeas.v1beta1.GetOccurrenceRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.Occurrence> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetOccurrenceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetOccurrenceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1222,7 +1093,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grafeas.v1beta1.ListOccurrencesRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.ListOccurrencesResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListOccurrencesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListOccurrencesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1240,7 +1111,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grafeas.v1beta1.DeleteOccurrenceRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteOccurrenceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteOccurrenceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1256,7 +1127,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grafeas.v1beta1.CreateOccurrenceRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.Occurrence> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateOccurrenceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateOccurrenceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1273,7 +1144,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.BatchCreateOccurrencesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchCreateOccurrencesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchCreateOccurrencesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1289,7 +1160,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grafeas.v1beta1.UpdateOccurrenceRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.Occurrence> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateOccurrenceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateOccurrenceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1306,7 +1177,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grafeas.v1beta1.GetOccurrenceNoteRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.Note> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetOccurrenceNoteMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetOccurrenceNoteMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1322,9 +1193,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grafeas.v1beta1.GetNoteRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.Note> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetNoteMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetNoteMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1338,9 +1207,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grafeas.v1beta1.ListNotesRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.ListNotesResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListNotesMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getListNotesMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1354,9 +1221,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grafeas.v1beta1.DeleteNoteRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteNoteMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getDeleteNoteMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1370,9 +1235,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grafeas.v1beta1.CreateNoteRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.Note> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateNoteMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getCreateNoteMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1386,7 +1249,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grafeas.v1beta1.BatchCreateNotesRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.BatchCreateNotesResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchCreateNotesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchCreateNotesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1402,9 +1265,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grafeas.v1beta1.UpdateNoteRequest request,
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.Note> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateNoteMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getUpdateNoteMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1421,7 +1282,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.ListNoteOccurrencesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListNoteOccurrencesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListNoteOccurrencesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1438,8 +1299,7 @@ public final class GrafeasV1Beta1Grpc {
         io.grpc.stub.StreamObserver<io.grafeas.v1beta1.VulnerabilityOccurrencesSummary>
             responseObserver) {
       asyncUnaryCall(
-          getChannel()
-              .newCall(getGetVulnerabilityOccurrencesSummaryMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetVulnerabilityOccurrencesSummaryMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1463,11 +1323,7 @@ public final class GrafeasV1Beta1Grpc {
    * </pre>
    */
   public static final class GrafeasV1Beta1BlockingStub
-      extends io.grpc.stub.AbstractStub<GrafeasV1Beta1BlockingStub> {
-    private GrafeasV1Beta1BlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<GrafeasV1Beta1BlockingStub> {
     private GrafeasV1Beta1BlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1487,8 +1343,7 @@ public final class GrafeasV1Beta1Grpc {
      */
     public io.grafeas.v1beta1.Occurrence getOccurrence(
         io.grafeas.v1beta1.GetOccurrenceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetOccurrenceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetOccurrenceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1500,8 +1355,7 @@ public final class GrafeasV1Beta1Grpc {
      */
     public io.grafeas.v1beta1.ListOccurrencesResponse listOccurrences(
         io.grafeas.v1beta1.ListOccurrencesRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListOccurrencesMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListOccurrencesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1516,7 +1370,7 @@ public final class GrafeasV1Beta1Grpc {
     public com.google.protobuf.Empty deleteOccurrence(
         io.grafeas.v1beta1.DeleteOccurrenceRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteOccurrenceMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteOccurrenceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1529,7 +1383,7 @@ public final class GrafeasV1Beta1Grpc {
     public io.grafeas.v1beta1.Occurrence createOccurrence(
         io.grafeas.v1beta1.CreateOccurrenceRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateOccurrenceMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateOccurrenceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1542,7 +1396,7 @@ public final class GrafeasV1Beta1Grpc {
     public io.grafeas.v1beta1.BatchCreateOccurrencesResponse batchCreateOccurrences(
         io.grafeas.v1beta1.BatchCreateOccurrencesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchCreateOccurrencesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchCreateOccurrencesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1555,7 +1409,7 @@ public final class GrafeasV1Beta1Grpc {
     public io.grafeas.v1beta1.Occurrence updateOccurrence(
         io.grafeas.v1beta1.UpdateOccurrenceRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateOccurrenceMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateOccurrenceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1569,7 +1423,7 @@ public final class GrafeasV1Beta1Grpc {
     public io.grafeas.v1beta1.Note getOccurrenceNote(
         io.grafeas.v1beta1.GetOccurrenceNoteRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetOccurrenceNoteMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetOccurrenceNoteMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1580,7 +1434,7 @@ public final class GrafeasV1Beta1Grpc {
      * </pre>
      */
     public io.grafeas.v1beta1.Note getNote(io.grafeas.v1beta1.GetNoteRequest request) {
-      return blockingUnaryCall(getChannel(), getGetNoteMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetNoteMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1592,7 +1446,7 @@ public final class GrafeasV1Beta1Grpc {
      */
     public io.grafeas.v1beta1.ListNotesResponse listNotes(
         io.grafeas.v1beta1.ListNotesRequest request) {
-      return blockingUnaryCall(getChannel(), getListNotesMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListNotesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1603,8 +1457,7 @@ public final class GrafeasV1Beta1Grpc {
      * </pre>
      */
     public com.google.protobuf.Empty deleteNote(io.grafeas.v1beta1.DeleteNoteRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteNoteMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteNoteMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1615,8 +1468,7 @@ public final class GrafeasV1Beta1Grpc {
      * </pre>
      */
     public io.grafeas.v1beta1.Note createNote(io.grafeas.v1beta1.CreateNoteRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateNoteMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateNoteMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1629,7 +1481,7 @@ public final class GrafeasV1Beta1Grpc {
     public io.grafeas.v1beta1.BatchCreateNotesResponse batchCreateNotes(
         io.grafeas.v1beta1.BatchCreateNotesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchCreateNotesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchCreateNotesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1640,8 +1492,7 @@ public final class GrafeasV1Beta1Grpc {
      * </pre>
      */
     public io.grafeas.v1beta1.Note updateNote(io.grafeas.v1beta1.UpdateNoteRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateNoteMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateNoteMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1656,7 +1507,7 @@ public final class GrafeasV1Beta1Grpc {
     public io.grafeas.v1beta1.ListNoteOccurrencesResponse listNoteOccurrences(
         io.grafeas.v1beta1.ListNoteOccurrencesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListNoteOccurrencesMethodHelper(), getCallOptions(), request);
+          getChannel(), getListNoteOccurrencesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1669,10 +1520,7 @@ public final class GrafeasV1Beta1Grpc {
     public io.grafeas.v1beta1.VulnerabilityOccurrencesSummary getVulnerabilityOccurrencesSummary(
         io.grafeas.v1beta1.GetVulnerabilityOccurrencesSummaryRequest request) {
       return blockingUnaryCall(
-          getChannel(),
-          getGetVulnerabilityOccurrencesSummaryMethodHelper(),
-          getCallOptions(),
-          request);
+          getChannel(), getGetVulnerabilityOccurrencesSummaryMethod(), getCallOptions(), request);
     }
   }
 
@@ -1694,11 +1542,7 @@ public final class GrafeasV1Beta1Grpc {
    * </pre>
    */
   public static final class GrafeasV1Beta1FutureStub
-      extends io.grpc.stub.AbstractStub<GrafeasV1Beta1FutureStub> {
-    private GrafeasV1Beta1FutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<GrafeasV1Beta1FutureStub> {
     private GrafeasV1Beta1FutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1719,7 +1563,7 @@ public final class GrafeasV1Beta1Grpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grafeas.v1beta1.Occurrence>
         getOccurrence(io.grafeas.v1beta1.GetOccurrenceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetOccurrenceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetOccurrenceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1733,7 +1577,7 @@ public final class GrafeasV1Beta1Grpc {
             io.grafeas.v1beta1.ListOccurrencesResponse>
         listOccurrences(io.grafeas.v1beta1.ListOccurrencesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListOccurrencesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListOccurrencesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1748,7 +1592,7 @@ public final class GrafeasV1Beta1Grpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteOccurrence(io.grafeas.v1beta1.DeleteOccurrenceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteOccurrenceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteOccurrenceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1761,7 +1605,7 @@ public final class GrafeasV1Beta1Grpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grafeas.v1beta1.Occurrence>
         createOccurrence(io.grafeas.v1beta1.CreateOccurrenceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateOccurrenceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateOccurrenceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1775,7 +1619,7 @@ public final class GrafeasV1Beta1Grpc {
             io.grafeas.v1beta1.BatchCreateOccurrencesResponse>
         batchCreateOccurrences(io.grafeas.v1beta1.BatchCreateOccurrencesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchCreateOccurrencesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchCreateOccurrencesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1788,7 +1632,7 @@ public final class GrafeasV1Beta1Grpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grafeas.v1beta1.Occurrence>
         updateOccurrence(io.grafeas.v1beta1.UpdateOccurrenceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateOccurrenceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateOccurrenceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1802,7 +1646,7 @@ public final class GrafeasV1Beta1Grpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grafeas.v1beta1.Note>
         getOccurrenceNote(io.grafeas.v1beta1.GetOccurrenceNoteRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetOccurrenceNoteMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetOccurrenceNoteMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1814,8 +1658,7 @@ public final class GrafeasV1Beta1Grpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<io.grafeas.v1beta1.Note> getNote(
         io.grafeas.v1beta1.GetNoteRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetNoteMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetNoteMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1827,8 +1670,7 @@ public final class GrafeasV1Beta1Grpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<io.grafeas.v1beta1.ListNotesResponse>
         listNotes(io.grafeas.v1beta1.ListNotesRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getListNotesMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getListNotesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1841,7 +1683,7 @@ public final class GrafeasV1Beta1Grpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> deleteNote(
         io.grafeas.v1beta1.DeleteNoteRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteNoteMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteNoteMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1854,7 +1696,7 @@ public final class GrafeasV1Beta1Grpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grafeas.v1beta1.Note> createNote(
         io.grafeas.v1beta1.CreateNoteRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateNoteMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateNoteMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1868,7 +1710,7 @@ public final class GrafeasV1Beta1Grpc {
             io.grafeas.v1beta1.BatchCreateNotesResponse>
         batchCreateNotes(io.grafeas.v1beta1.BatchCreateNotesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchCreateNotesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchCreateNotesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1881,7 +1723,7 @@ public final class GrafeasV1Beta1Grpc {
     public com.google.common.util.concurrent.ListenableFuture<io.grafeas.v1beta1.Note> updateNote(
         io.grafeas.v1beta1.UpdateNoteRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateNoteMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateNoteMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1897,7 +1739,7 @@ public final class GrafeasV1Beta1Grpc {
             io.grafeas.v1beta1.ListNoteOccurrencesResponse>
         listNoteOccurrences(io.grafeas.v1beta1.ListNoteOccurrencesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListNoteOccurrencesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListNoteOccurrencesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1912,8 +1754,7 @@ public final class GrafeasV1Beta1Grpc {
         getVulnerabilityOccurrencesSummary(
             io.grafeas.v1beta1.GetVulnerabilityOccurrencesSummaryRequest request) {
       return futureUnaryCall(
-          getChannel()
-              .newCall(getGetVulnerabilityOccurrencesSummaryMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetVulnerabilityOccurrencesSummaryMethod(), getCallOptions()),
           request);
     }
   }
@@ -2095,21 +1936,21 @@ public final class GrafeasV1Beta1Grpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new GrafeasV1Beta1FileDescriptorSupplier())
-                      .addMethod(getGetOccurrenceMethodHelper())
-                      .addMethod(getListOccurrencesMethodHelper())
-                      .addMethod(getDeleteOccurrenceMethodHelper())
-                      .addMethod(getCreateOccurrenceMethodHelper())
-                      .addMethod(getBatchCreateOccurrencesMethodHelper())
-                      .addMethod(getUpdateOccurrenceMethodHelper())
-                      .addMethod(getGetOccurrenceNoteMethodHelper())
-                      .addMethod(getGetNoteMethodHelper())
-                      .addMethod(getListNotesMethodHelper())
-                      .addMethod(getDeleteNoteMethodHelper())
-                      .addMethod(getCreateNoteMethodHelper())
-                      .addMethod(getBatchCreateNotesMethodHelper())
-                      .addMethod(getUpdateNoteMethodHelper())
-                      .addMethod(getListNoteOccurrencesMethodHelper())
-                      .addMethod(getGetVulnerabilityOccurrencesSummaryMethodHelper())
+                      .addMethod(getGetOccurrenceMethod())
+                      .addMethod(getListOccurrencesMethod())
+                      .addMethod(getDeleteOccurrenceMethod())
+                      .addMethod(getCreateOccurrenceMethod())
+                      .addMethod(getBatchCreateOccurrencesMethod())
+                      .addMethod(getUpdateOccurrenceMethod())
+                      .addMethod(getGetOccurrenceNoteMethod())
+                      .addMethod(getGetNoteMethod())
+                      .addMethod(getListNotesMethod())
+                      .addMethod(getDeleteNoteMethod())
+                      .addMethod(getCreateNoteMethod())
+                      .addMethod(getBatchCreateNotesMethod())
+                      .addMethod(getUpdateNoteMethod())
+                      .addMethod(getListNoteOccurrencesMethod())
+                      .addMethod(getGetVulnerabilityOccurrencesSummaryMethod())
                       .build();
         }
       }

--- a/synth.py
+++ b/synth.py
@@ -15,16 +15,12 @@
 """This script is used to synthesize generated parts of this library."""
 
 import synthtool as s
-import synthtool.gcp as gcp
 import synthtool.languages.java as java
 
 AUTOSYNTH_MULTIPLE_COMMITS = True
 
-gapic = gcp.GAPICGenerator()
-
-service = 'containeranalysis'
+service = 'devtools-containeranalysis'
 versions = ['v1beta1', 'v1']
-config_pattern = '/google/devtools/containeranalysis/artman_containeranalysis_{version}.yaml'
 
 get_grafeas_code = """
   /**
@@ -39,23 +35,25 @@ get_grafeas_code = """
 
 
 for version in versions:
-  library = java.gapic_library(
+  java.bazel_library(
       service=service,
       version=version,
-      config_pattern=config_pattern,
+      proto_path=f'google/devtools/containeranalysis/{version}',
+      bazel_target=f'//google/devtools/containeranalysis/{version}:google-cloud-{service}-{version}-java',
+      destination_name='containeranalysis',
   )
 
   if version == 'v1':
       # add GrafeasClient import
       s.replace(
-          f'google-cloud-{service}/src/main/java/com/google/cloud/devtools/containeranalysis/{version}/ContainerAnalysisClient.java',
+          f'google-cloud-containeranalysis/src/main/java/com/google/cloud/devtools/containeranalysis/{version}/ContainerAnalysisClient.java',
           'import com.google.iam.v1.TestIamPermissionsResponse;',
           'import com.google.iam.v1.TestIamPermissionsResponse;\nimport io.grafeas.v1.GrafeasClient;'
       )
 
       # add getGrafeasClient()
       s.replace(
-          f'google-cloud-{service}/src/main/java/com/google/cloud/devtools/containeranalysis/{version}/ContainerAnalysisClient.java',
+          f'google-cloud-containeranalysis/src/main/java/com/google/cloud/devtools/containeranalysis/{version}/ContainerAnalysisClient.java',
           r'(\s+private final ContainerAnalysisStub stub;.*)',
           f'\g<1>{get_grafeas_code}'
       )


### PR DESCRIPTION
As suggested in https://github.com/googleapis/java-talent/pull/100, this PR only updates the synth.py itself to use bazel. The updatged generated code will be published separately by yoshi, because it includes breaking changes in resource names, caused not by the bazel migration but by the chnages in the generator itself.

